### PR TITLE
Use HMAC of the key over the secret to digest it

### DIFF
--- a/lib/attr_vault/keyring.rb
+++ b/lib/attr_vault/keyring.rb
@@ -18,6 +18,10 @@ module AttrVault
       @created_at = created_at
     end
 
+    def digest(data)
+      AttrVault::Encryption::hmac_digest(value, data)
+    end
+
     def to_json(*args)
       { id: id, value: value, created_at: created_at }.to_json
     end
@@ -76,6 +80,10 @@ module AttrVault
         raise KeyringEmpty, "No keys in keyring"
       end
       k
+    end
+
+    def digests(data)
+      keys.map { |k| k.digest(data) }
     end
 
     def to_json

--- a/spec/attr_vault_spec.rb
+++ b/spec/attr_vault_spec.rb
@@ -355,17 +355,16 @@ describe AttrVault do
 
   context "with a digest field" do
     let(:key_id)   { '80a8571b-dc8a-44da-9b89-caee87e41ce2' }
-    let(:key_data) {
-      [{
-        id: key_id,
+    let (:key) {
+      [{id: key_id,
         value: 'aFJDXs+798G7wgS/nap21LXIpm/Rrr39jIVo2m/cdj8=',
-        created_at: Time.now }].to_json
+        created_at: Time.now}]
     }
     let(:item)   {
       # the let form can't be evaluated inside the class definition
       # because Ruby scoping rules were written by H.P. Lovecraft, so
       # we create a local here to work around that
-      k = key_data
+      k = key.to_json
       Class.new(Sequel::Model(:items)) do
         include AttrVault
         vault_keyring k
@@ -374,24 +373,29 @@ describe AttrVault do
       end
     }
 
+    def test_digest(key, data)
+      OpenSSL::HMAC.digest(OpenSSL::Digest.new('sha256'),
+        key.first.fetch(:value), data)
+    end
+
     it "records the sha1 of the plaintext value" do
       secret = 'snape kills dumbledore'
       s = item.create(secret: secret)
-      expect(s.secret_digest).to eq(Digest::SHA1.hexdigest(secret))
+      expect(s.secret_digest).to eq(test_digest(key, secret))
     end
 
     it "can record multiple digest fields" do
       secret = 'joffrey kills ned'
       other_secret = '"gomer pyle" lawrence kills himself'
       s = item.create(secret: secret, other: other_secret)
-      expect(s.secret_digest).to eq(Digest::SHA1.hexdigest(secret))
-      expect(s.other_digest).to eq(Digest::SHA1.hexdigest(other_secret))
+      expect(s.secret_digest).to eq(test_digest(key, secret))
+      expect(s.other_digest).to eq(test_digest(key, other_secret))
     end
 
     it "records the digest for an empty field" do
       s = item.create(secret: '', other: '')
-      expect(s.secret_digest).to eq(Digest::SHA1.hexdigest(''))
-      expect(s.other_digest).to eq(Digest::SHA1.hexdigest(''))
+      expect(s.secret_digest).to eq(test_digest(key, ''))
+      expect(s.other_digest).to eq(test_digest(key, ''))
     end
 
     it "records the digest of a nil field" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,9 +20,9 @@ conn.run <<-EOF
       key_id uuid,
       alt_key_id uuid,
       secret_encrypted bytea,
-      secret_digest text,
+      secret_digest bytea,
       other_encrypted bytea,
-      other_digest text,
+      other_digest bytea,
       not_secret text,
       other_not_secret text
     )


### PR DESCRIPTION
Primarily to avoid oracle attacks, whereby guessing a small space of
known to be valid outputs can be used to check the existence of a digest
in the data set.  The encryption key, known to be high entropy if
generated in a normal manner, being used to key HMAC should avoid that
attack.

As a downside, it is now more difficult and computationally expensive to
find encrypted values without decryption or compromising the contents.
It can still be done, however.  Prior to this patch, a program could
search for a value like this:

```
WHERE digest_columm = digest(val)
```

Now, it will be necessary to digest using every HMAC key and checking
for a match. This seems acceptable if the keyring is kept fairly small,
as is the intended use.  For example:

```
WHERE digest_column IN (digest_1(val), digest_2(val))
```

This is aided by the new "vault_digests(data)" Sequel class method,
which can generate the digest array given the relevant keyring and
payload for the Sequel model in question.

While making this breaking change, also take the opportunity to convert
the digests to binary coding, which should be slightly faster and more
compact for equality matching.  It also streamlines attr_vault's code by
avoiding digest/hexdigest operator confusion.
