### PR TITLE
Compare id in a non case sensitive way

### DIFF
--- a/lib/attr_vault/keyring.rb
+++ b/lib/attr_vault/keyring.rb
@@ -63,15 +63,15 @@ module AttrVault
            else
              id_or_key
            end
-      @keys.reject! { |k| k.id == id }
+      @keys.reject! { |k| k.id == id.downcase }
     end
 
     def fetch(id)
-      @keys.find { |k| k.id == id } or raise UnknownKey, id
+      @keys.find { |k| k.id == id.downcase } or raise UnknownKey, id
     end
 
     def has_key?(id)
-      !@keys.find { |k| k.id == id }.nil?
+      !@keys.find { |k| k.id == id.downcase }.nil?
     end
 
     def current_key

--- a/spec/attr_vault/keyring_spec.rb
+++ b/spec/attr_vault/keyring_spec.rb
@@ -77,6 +77,11 @@ module AttrVault
       expect(keyring.fetch(k2.id)).to be k2
     end
 
+    it "finds the right key by its id without case issues" do
+      expect(keyring.fetch(k1.id.upcase)).to be k1
+      expect(keyring.fetch(k2.id.upcase)).to be k2
+    end
+
     it "raises for an unknown id" do
       expect { keyring.fetch('867344d2-ac73-493b-9a9e-5fa688ba25ef') }
         .to raise_error(UnknownKey)


### PR DESCRIPTION
uuidgen on linux or mac generates keys that are uppercase.
Once stored, they are downcased and comparing them fails.