### PR TITLE
Add bridge for standard Sequel Plugin compatibility

### DIFF
--- a/lib/sequel/plugins/attr_vault.rb
+++ b/lib/sequel/plugins/attr_vault.rb
@@ -1,0 +1,12 @@
+require 'sequel'
+
+module Sequel
+  module Plugins
+    module AttrVault
+      def self.apply(model, opts={})
+        model.extend ::AttrVault::ClassMethods
+        model.include ::AttrVault::InstanceMethods
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is just a bridge so people can keep doing `include AttrVault`. But with this they can use the more traditional approach, like:

``` ruby
class MyModel < Sequel::Model
  plugin :attr_vault
```

What do you think of just breaking compatibility and going 100% plugin route? Could change the interface, like:

``` ruby
class MyModell < Sequel::Model
  plugin :attr_vault, keyring: Config.attr_vault_keyring, fields: [ :my_secret_field ]
```

I can tweak this pull if you like this path. Or if you want to explore by yourself, check the Sequel plugin docs:
http://sequel.jeremyevans.net/rdoc/files/doc/model_plugins_rdoc.html
