### PR TITLE
Loosen dependency on pg gem to allow 0.19 and newer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     attr_vault (0.2.0)
-      pg (~> 0.18.3)
+      pg (~> 0.18)
       sequel (~> 4.13)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.5)
-    pg (0.18.3)
+    pg (0.19.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -22,13 +22,17 @@ GEM
     rspec-mocks (3.1.3)
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
-    sequel (4.13.0)
+    sequel (4.43.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   attr_vault!
-  pg (~> 0.18.3)
   rspec (~> 3.0)
-  sequel (~> 4.13)
+
+RUBY VERSION
+   ruby 2.2.2p95
+
+BUNDLED WITH
+   1.14.5

--- a/attr_vault.gemspec
+++ b/attr_vault.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = AttrVault::VERSION
   gem.license       = "MIT"
 
-  gem.add_runtime_dependency "pg", '~> 0.18.3'
+  gem.add_runtime_dependency "pg", '~> 0.18'
   gem.add_runtime_dependency "sequel", '~> 4.13'
 
   gem.add_development_dependency "rspec", '~> 3.0'


### PR DESCRIPTION
Right now you can't use attr_vault with pg 0.19, and Bundler tries to be smart and installs an older attr_vault (0.1.2) by default, which satisfies the 0.19 relationship.

There is no obvious reason why attr_vault 0.2.0 can't support pg 0.19 (or newer).