### PR TITLE
Forward-compatibility with 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.5.3'
 
 # Specify your gem's dependencies in attr_vault.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,3 +30,9 @@ DEPENDENCIES
   pg (~> 0)
   rspec (~> 3.0)
   sequel (~> 4.13)
+
+RUBY VERSION
+   ruby 2.5.3p105
+
+BUNDLED WITH
+   1.17.1

--- a/lib/attr_vault.rb
+++ b/lib/attr_vault.rb
@@ -57,14 +57,18 @@ module AttrVault
         end
       end
       self[self.class.vault_key_field] = current_key.id
+      if self.class.vault_new_key_field
+        self[self.class.vault_new_key_field] = current_key.new_id
+      end
       @vault_dirty_attrs = {}
       super
     end
   end
 
   module ClassMethods
-    def vault_keyring(keyring_data, key_field: :key_id)
+    def vault_keyring(keyring_data, key_field: :key_id, new_key_field: nil)
       @key_field = key_field.to_sym
+      @new_key_field = new_key_field
       @keyring = Keyring.load(keyring_data)
     end
 
@@ -119,6 +123,10 @@ module AttrVault
 
     def vault_key_field
       @key_field
+    end
+
+    def vault_new_key_field
+      @new_key_field
     end
 
     def vault_keys

--- a/lib/attr_vault/keyring.rb
+++ b/lib/attr_vault/keyring.rb
@@ -1,8 +1,8 @@
 module AttrVault
   class Key
-    attr_reader :id, :value, :created_at
+    attr_reader :id, :value, :created_at, :new_id
 
-    def initialize(id, value, created_at)
+    def initialize(id, value, created_at, new_id=nil)
       if id.nil?
         raise InvalidKey, "key id required"
       end
@@ -16,6 +16,7 @@ module AttrVault
       @id = id
       @value = value
       @created_at = created_at
+      @new_id = new_id
     end
 
     def to_json(*args)
@@ -37,7 +38,7 @@ module AttrVault
           created_at = unless k["created_at"].nil?
                          Time.parse(k["created_at"])
                        end
-          keyring.add_key(Key.new(k["id"], k["value"], created_at || Time.now))
+          keyring.add_key(Key.new(k["id"], k["value"], created_at || Time.now, k["new_id"]))
         end
       rescue StandardError => e
         raise InvalidKeyring, e.message

--- a/spec/attr_vault/keyring_spec.rb
+++ b/spec/attr_vault/keyring_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "json"
+require "securerandom"
 
 module AttrVault
   describe Keyring do
@@ -7,8 +8,8 @@ module AttrVault
     describe ".load" do
       let(:key_data) {
         [
-         { id: SecureRandom.uuid, value: SecureRandom.base64(32), created_at: Time.now },
-         { id: SecureRandom.uuid, value: SecureRandom.base64(32), created_at: Time.now }
+         { id: SecureRandom.uuid, value: SecureRandom.base64(32), created_at: Time.now, new_id: 1 },
+         { id: SecureRandom.uuid, value: SecureRandom.base64(32), created_at: Time.now, new_id: 2 }
         ]
       }
 
@@ -20,6 +21,7 @@ module AttrVault
           expect(keyring.keys[i].id).to eq key_data[i][:id]
           expect(keyring.keys[i].value).to eq key_data[i][:value]
           expect(keyring.keys[i].created_at).to be_within(60).of(key_data[i][:created_at])
+          expect(keyring.keys[i].new_id).to eq key_data[i][:new_id]
         end
       end
 

--- a/spec/attr_vault_spec.rb
+++ b/spec/attr_vault_spec.rb
@@ -369,6 +369,36 @@ describe AttrVault do
     end
   end
 
+  context "with a new_key_field" do
+    let(:key_id)     { '80a8571b-dc8a-44da-9b89-caee87e41ce2' }
+    let(:new_key_id) { 1 }
+    let(:key_data)   {
+      [{
+         id: key_id,
+         new_id: new_key_id,
+         value: 'aFJDXs+798G7wgS/nap21LXIpm/Rrr39jIVo2m/cdj8=',
+         created_at: Time.now }].to_json
+    }
+    let(:item)       {
+      k = key_data
+      Class.new(Sequel::Model(:items)) do
+        include AttrVault
+        vault_keyring k, new_key_field: 'new_key_id'
+        vault_attr :secret
+      end
+    }
+
+    it "records the new key id in the given field" do
+      secret = "the enigma machine code"
+      s = item.create(secret: secret)
+      s.reload
+      expect(s.secret).to eq secret
+      expect(s.secret_encrypted).not_to eq secret
+      expect(s.key_id).to eq key_id
+      expect(s.new_key_id).to eq new_key_id
+    end
+  end
+
   context "with a digest field" do
     let(:key_id)   { '80a8571b-dc8a-44da-9b89-caee87e41ce2' }
     let(:key_data) {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ conn.run <<-EOF
       id serial primary key,
       key_id uuid,
       alt_key_id uuid,
+      new_key_id integer,
       secret_encrypted bytea,
       secret_digest text,
       other_encrypted bytea,


### PR DESCRIPTION
This adds an optional `new_key_field` option to the `vault_keyring` class method added by AttrVault. If set, it will write the new optional `new_id` field from the corresponding key in the keyring along with the standard `key_id` column. This makes it easier to migrate to 2.x.

@mdaniels2 can you please take a look?