### PR TITLE
Fix warning when used with Ruby 2.7+

### DIFF
--- a/lib/attr_vault.rb
+++ b/lib/attr_vault.rb
@@ -74,7 +74,7 @@ module AttrVault
     end
 
     def vault_attr(name, opts={})
-      attr = VaultAttr.new(name, opts)
+      attr = VaultAttr.new(name, **opts)
       self.vault_attrs << attr
 
       define_method(name) do


### PR DESCRIPTION
This should fix https://github.com/uhoh-itsmaciek/attr_vault/issues/31