### PR TITLE
Add a parameter to Keyring.initialize: use_nth_newest_key

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.7.1'
+ruby '~> 2.7'
 
 # Specify your gem's dependencies in attr_vault.gemspec
 gemspec

--- a/lib/attr_vault.rb
+++ b/lib/attr_vault.rb
@@ -64,9 +64,9 @@ module AttrVault
   end
 
   module ClassMethods
-    def vault_keyring(keyring_data, key_field: :key_id)
+    def vault_keyring(keyring_data, key_field: :key_id, use_nth_newest_key: 1)
       @key_field = key_field.to_sym
-      @keyring = Keyring.load(keyring_data)
+      @keyring = Keyring.load(keyring_data, use_nth_newest_key)
     end
 
     def vault_digests(data)

--- a/lib/attr_vault/keyring.rb
+++ b/lib/attr_vault/keyring.rb
@@ -26,10 +26,10 @@ module AttrVault
   end
 
   class Keyring
-    attr_reader :keys
+    attr_reader :keys, :use_nth_newest_key
 
-    def self.load(keyring_data)
-      keyring = Keyring.new
+    def self.load(keyring_data, use_nth_newest_key = 1)
+      keyring = Keyring.new(use_nth_newest_key)
       begin
         candidate_keys = JSON.parse(keyring_data, symbolize_names: true)
 
@@ -46,8 +46,9 @@ module AttrVault
       keyring
     end
 
-    def initialize
+    def initialize(use_nth_newest_key = 1)
       @keys = []
+	  @use_nth_newest_key = use_nth_newest_key
     end
 
     def add_key(k)
@@ -72,7 +73,7 @@ module AttrVault
     end
 
     def current_key
-      k = @keys.sort_by(&:id).last
+      k = @keys.max_by(@use_nth_newest_key, &:id).last
       if k.nil?
         raise KeyringEmpty, "No keys in keyring"
       end

--- a/spec/attr_vault/keyring_spec.rb
+++ b/spec/attr_vault/keyring_spec.rb
@@ -171,6 +171,16 @@ module AttrVault
       expect(keyring.current_key).to eq k2
     end
 
+    it "returns the key with second largest id when use_nth_newest_key set to 2" do
+      ring = Keyring.new(2)
+      ring.add_key(k1)
+      expect(ring.current_key).to eq k1
+      ring.add_key(k2)
+      expect(ring.current_key).to eq k1
+      ring.add_key(Key.new(3, ::SecureRandom.base64(32)))
+      expect(ring.current_key).to eq k2
+    end
+
     it "raise if no keys are registered" do
       other_keyring = Keyring.new
       expect { other_keyring.current_key }.to raise_error(KeyringEmpty)


### PR DESCRIPTION
This is useful for rotating keys with gradual restart of multiple processes,
where old processes should read values encrypted by the newly promoted current_key.